### PR TITLE
adding "urbit uueb" to ##applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated collection of projects and tools in the Urbit ecosystem.
 - [srrs](https://github.com/ryjm/srrs) – a spaced repetition repetition system on urbit
 - [Calendar](https://github.com/taalhavras/ucal) - a calendar styled after Google Calendar
 - [Canvas](https://github.com/yosoyubik/canvas) - a collaborative drawing application
+- [Fang Suite](https://github.com/Fang-/suite) - various apps, tools, and crazy experiments. usage encouraged! issues welcome! provided "as is"!
 
 ## Games
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A curated collection of projects and tools in the Urbit ecosystem.
 - [Venetia](https://github.com/tylershuster/venetia) — a simple command-line utility for generating a list of planet names issuable from an Urbit star.
 - [Urbit Content Archiver](https://github.com/robkorn/urbit-content-archiver) — CLI application that exports channels from your Urbit ship and auto-downloads any directly linked content.
 - [Urbit Webhook Funnel](https://github.com/robkorn/urbit-webhook-funnel) - CLI application which funnels external webhook event data to an Urbit chat.
+- [Graph Store Text Search](https://github.com/h5gq3/graph-query) - Basic Text Search for graph-store based urbit apps, like Chat, Collections, and Notebooks. CLI-only.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated collection of projects and tools in the Urbit ecosystem.
 - [srrs](https://github.com/ryjm/srrs) – a spaced repetition repetition system on urbit
 - [Calendar](https://github.com/taalhavras/ucal) - a calendar styled after Google Calendar
 - [Canvas](https://github.com/yosoyubik/canvas) - a collaborative drawing application
-- [Fang Suite](https://github.com/Fang-/suite) - various apps, tools, and crazy experiments. usage encouraged! issues welcome! provided "as is"!
+- [Urbit uuweb](http://ashtree.systems/uuulogin/login.html) - A restricted subset of the www. Access to the uuu is gated by owning an Urbit planet.
 
 ## Games
 


### PR DESCRIPTION
Adding the "Urbit uuweb" project to "Applications", as an example of how Urbit ID can be used to "gate" existing web content